### PR TITLE
Updated <Link>s to remove deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run this thing locally
 
 Clone the repository, `cd` into it, and `npm install`
 
-copy `/config.example.js` to `/config.js`, and update the `api` and `self` values. if you're just looking to contribute to the main instance at https://metapolis.space, you can simply change the values to:
+copy `/config.js.example` to `/config.js`, and update the `api` and `self` values. if you're just looking to contribute to the main instance at https://metapolis.space, you can simply change the values to:
 
 ```js
 {

--- a/components/layout.js
+++ b/components/layout.js
@@ -10,7 +10,7 @@ export default (props) => (<div className="root">
   </Head>
   <header className='Masthead'>
     <h1> {props.auth ? props.auth.token.team_name : '' } Slack Helper </h1>
-    <Link href='/'><a style={ { color: 'white' , textDecoration: 'none' } }>Home</a></Link>
+    <Link><a href='/' style={ { color: 'white' , textDecoration: 'none' } }>Home</a></Link>
   </header>
   <main>
     {props.children}

--- a/components/menu.js
+++ b/components/menu.js
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 
-export default () => <nav>
-  <p><Link href='/'>Home</Link></p>
-  <p><Link href='/purge'>Purge Private Files</Link></p>
-  <p><Link href='/upload'>Upload File</Link></p>
-  <p><Link href='/list'>List Your Files</Link></p>
-  <p><Link href='/logout'>Log Out</Link></p>
-</nav>;
+export default () => (
+  <nav>
+    <p><Link><a href='/'>Home</a></Link></p>
+    <p><Link><a href='/purge'>Purge Private Files</a></Link></p>
+    <p><Link><a href='/upload'>Upload File</a></Link></p>
+    <p><Link><a href='/list'>List Your Files</a></Link></p>
+    <p><Link><a href='/logout'>Log Out</a></Link></p>
+  </nav>
+);

--- a/config.js.example
+++ b/config.js.example
@@ -1,4 +1,0 @@
-export default {
-    api: 'https://api.yayforqueers.net/',
-    self: 'https://service/'
-}

--- a/config.js.example
+++ b/config.js.example
@@ -1,0 +1,4 @@
+export default {
+    api: 'https://api.yayforqueers.net/',
+    self: 'https://service/'
+}

--- a/pages/list.js
+++ b/pages/list.js
@@ -21,11 +21,23 @@ export default AuthRequired(class extends React.Component {
 
   render() {
     console.warn(this.props);
-    return <Layout auth={this.props.auth}>
-      <h2>Your files</h2>
-      {
-        this.props.files ? this.props.files.map(file => <div key={file.file}><Link href={`/file?f=${file.team}/${file.user}/${file.file}`}>{ file.title || file.name || 'untitled' }</Link></div>) : "No files"
-      }
-    </Layout>;
+
+    const files = this.props.files ? this.props.files.map(file => (
+      <div key={file.file}>
+        <Link>
+          <a href={`/file?f=${file.team}/${file.user}/${file.file}`}>
+            { file.title || file.name || 'untitled' }
+          </a>
+        </Link>
+      </div>
+    )) : 'No files';
+
+    return(
+      <Layout auth={this.props.auth}>
+        <h2>Your files</h2>
+
+        { files }
+      </Layout>
+    );
   }
 })


### PR DESCRIPTION
next's `<Link>` component took a String `href` prop -- this has been deprecated, and the new recommended usage is to include an anchor tag as a child of the `<Link>`.

this PR updates all the `<Link>`s to include anchor tag children and remove the deprecation warning.