### PR TITLE
Disable the Upload button when it's clicked

### DIFF
--- a/pages/upload.js
+++ b/pages/upload.js
@@ -70,7 +70,7 @@ export default AuthRequired(PERMS, class extends React.Component {
               />
             </label>
           </div>
-          <Button disabled={!this.state.channel} dark>Share</Button>
+          <Button disabled={!this.state.channel || this.state.uploading} dark>Share</Button>
         </form>
       : <div/>
 
@@ -90,6 +90,7 @@ export default AuthRequired(PERMS, class extends React.Component {
   async handleUpload() {
     const data = new FormData();
     let n = 0;
+    this.state.uploading = true;
     this.state.files.forEach(f => data.append(`file-${n++}`, f))
     data.append('unfurl', String(this.state.unfurl));
     data.append('title', String(this.state.title));
@@ -114,6 +115,7 @@ export default AuthRequired(PERMS, class extends React.Component {
         text: image
       });
     }
+    this.state.uploading = false;
     this.props.url.push('/');
   }
 


### PR DESCRIPTION
On mobile in particular, it can be hard to tell if you successfully clicked the button or clumsily scrolled the page. The share-to-slack function can take several seconds and there's no indication that it's in progress, which exacerbates the problem.

Setting the button to disabled gives a visual indication that the share is indeed in progress.