### PR TITLE
Increase lifetime of session cookie

### DIFF
--- a/pages/auth.js
+++ b/pages/auth.js
@@ -34,10 +34,12 @@ export default class extends React.Component {
         }
 
 	if (body.sid) {
+	    const expires = new Date();
+	    expires.setDate(expires.getDate() + 30);
 	    if (res) {
-		res.setHeader('Set-Cookie', cookie.serialize('session', body.sid));
+		res.setHeader('Set-Cookie', cookie.serialize('session', body.sid, { expires }));
 	    } else {
-		document.cookie = cookie.serialize('session', body.sid);
+		document.cookie = cookie.serialize('session', body.sid, { expires });
 	    }
 	}
 

--- a/pages/auth.js
+++ b/pages/auth.js
@@ -36,10 +36,11 @@ export default class extends React.Component {
 	if (body.sid) {
 	    const expires = new Date();
 	    expires.setDate(expires.getDate() + 30);
+	    const sessionCookie = cookie.serialize('session', body.sid, { expires });
 	    if (res) {
-		res.setHeader('Set-Cookie', cookie.serialize('session', body.sid, { expires }));
+		res.setHeader('Set-Cookie', sessionCookie);
 	    } else {
-		document.cookie = cookie.serialize('session', body.sid, { expires });
+		document.cookie = sessionCookie;
 	    }
 	}
 


### PR DESCRIPTION
This fixes #20 by setting an expiry date on the session cookie, removing the session flag. It should survive a browser restart now.

I set the expiry date to 30 days in the future. Does that seem reasonable?

Thanks so much for creating this tool!